### PR TITLE
Function or function name args

### DIFF
--- a/R/download_classes.R
+++ b/R/download_classes.R
@@ -192,15 +192,15 @@ methods::setMethod(
 #' and/or ArrayExpress
 #'
 #' @param        acc           An accession number for use at GEO or
-#'   ArrayExpress
+#'   ArrayExpress.
 #' @param        database      The name of the database from which the dataset
-#'   should be downloaded
-#' @param        dl_func_name   The name of a function for downloading the
-#'   required dataset
+#'   should be downloaded.
+#' @param        download_method   Either a function (or the name of a
+#'   function) for downloading the required dataset.
 #' @param        dest_dir      The directory within which the dataset should be
-#'   saved
+#'   saved.
 #' @param        gpl_acc       The accession number for any relevant GPL
-#'   annotation data from GEO
+#'   annotation data from GEO.
 #' @param        annot_gpl     Should the NCBI-embellished platform annotation
 #'   data be downloaded?
 #'
@@ -209,20 +209,22 @@ methods::setMethod(
 #' @export
 #'
 
-# nolint start
 MicroarrayDownloadConfig <- function(
-                                     # nolint end
                                      acc,
                                      database,
-                                     dl_func_name,
+                                     download_method,
                                      dest_dir = tempdir(),
                                      gpl_acc = as.character(NA),
                                      annot_gpl) {
+  if (is.character(download_method)) {
+    download_method <- .get_from_env(download_method)
+  }
+
   new(
     "MicroarrayDownloadConfig",
     acc = acc,
     database = database,
-    dl_method = .get_from_env(dl_func_name),
+    dl_method = download_method,
     dest_dir = dest_dir,
     gpl_acc = gpl_acc,
     annot_gpl = annot_gpl

--- a/R/import_classes.R
+++ b/R/import_classes.R
@@ -116,9 +116,15 @@ methods::setMethod(
 #' Sets up a class for storing the options for importing datasets from GEO
 #' and/or ArrayExpress
 #'
-#' @param        acc           ABC
-#' @param        import_method   DEF
-#' @param        normalise_method   FED
+#' @param        acc           An identifier for the microarray dataset.
+#'   Typically this would be the GEO or ArrayExpress identifier.
+#' @param        import_method   Either a function or the name of a function
+#'   to be used for importing the microarray files into R. The function-name
+#'   can either be specified in "function_name" (if the function is defined in
+#'   the calling environment) or "pkg_name::function_name".
+#' @param        normalise_method   Either a function or the name of a function
+#'   to be used for normalising the imported microarray data. The function-name
+#'   can be provided in "function_name" or "pkg_name::function_name" format.
 #' @param        raw_dir       GHI
 #' @param        raw_files     JKL
 #' @param        raw_archive   MNO
@@ -150,9 +156,23 @@ MicroarrayImportConfig <- function(
                                    gpl_dir         = as.character(NA),
                                    gpl_files       = as.character(NA),
                                    annot_gpl       = as.logical(NA)) {
+  # Ensure that the import-method is defined, and, if specified by name
+  # convert that function name to the equivalent function.
   if (missing(import_method)) {
     stop("import_method should be defined")
   }
+  if(is.character(import_method)) {
+    import_method <- .get_from_env(import_method)
+  }
+  # Ensure that the normalise-method is defined, and, if specified by name
+  # convert that function name to the equivalent function.
+  if (missing(normalise_method)) {
+    stop("normalise_method should be defined")
+  }
+  if (is.character(normalise_method)) {
+    normalise_method <- .get_from_env(normalise_method)
+  }
+
   # Tried to do the following with do.call("new",
   # append(list("MicroarrayImportConfig"), args)) but it threw a C stack
   # problem

--- a/man/MicroarrayDownloadConfig.Rd
+++ b/man/MicroarrayDownloadConfig.Rd
@@ -5,24 +5,24 @@
 \title{Sets up a class for storing the options for downloading datasets from GEO
 and/or ArrayExpress}
 \usage{
-MicroarrayDownloadConfig(acc, database, dl_func_name,
+MicroarrayDownloadConfig(acc, database, download_method,
   dest_dir = tempdir(), gpl_acc = as.character(NA), annot_gpl)
 }
 \arguments{
 \item{acc}{An accession number for use at GEO or
-ArrayExpress}
+ArrayExpress.}
 
 \item{database}{The name of the database from which the dataset
-should be downloaded}
+should be downloaded.}
 
-\item{dl_func_name}{The name of a function for downloading the
-required dataset}
+\item{download_method}{Either a function (or the name of a
+function) for downloading the required dataset.}
 
 \item{dest_dir}{The directory within which the dataset should be
-saved}
+saved.}
 
 \item{gpl_acc}{The accession number for any relevant GPL
-annotation data from GEO}
+annotation data from GEO.}
 
 \item{annot_gpl}{Should the NCBI-embellished platform annotation
 data be downloaded?}

--- a/man/MicroarrayImportConfig.Rd
+++ b/man/MicroarrayImportConfig.Rd
@@ -15,11 +15,17 @@ MicroarrayImportConfig(acc, import_method, normalise_method,
   annot_gpl = as.logical(NA))
 }
 \arguments{
-\item{acc}{ABC}
+\item{acc}{An identifier for the microarray dataset.
+Typically this would be the GEO or ArrayExpress identifier.}
 
-\item{import_method}{DEF}
+\item{import_method}{Either a function or the name of a function
+to be used for importing the microarray files into R. The function-name
+can either be specified in "function_name" (if the function is defined in
+the calling environment) or "pkg_name::function_name".}
 
-\item{normalise_method}{FED}
+\item{normalise_method}{Either a function or the name of a function
+to be used for normalising the imported microarray data. The function-name
+can be provided in "function_name" or "pkg_name::function_name" format.}
 
 \item{raw_dir}{GHI}
 

--- a/tests/testthat/test-download_classes.R
+++ b/tests/testthat/test-download_classes.R
@@ -15,7 +15,7 @@ test_that("MicroarrayDownloadConfig: constructor", {
   # Using constructor function, with all args provided
   expect_s4_class(
     object = MicroarrayDownloadConfig(
-      acc = "GSE123", database = "geo", dl_func_name = "dl_geo_raw",
+      acc = "GSE123", database = "geo", download_method = "dl_geo_raw",
       dest_dir = tempdir(), gpl_acc = "GPL987", annot_gpl = TRUE
     ),
     class = "MicroarrayDownloadConfig"
@@ -23,7 +23,7 @@ test_that("MicroarrayDownloadConfig: constructor", {
 
   expect_equal(
     object = MicroarrayDownloadConfig(
-      acc = "GSE123", database = "geo", dl_func_name = "dl_geo_raw",
+      acc = "GSE123", database = "geo", download_method = "dl_geo_raw",
       dest_dir = tempdir(), gpl_acc = "GPL987", annot_gpl = TRUE
     ),
     expected = new(
@@ -39,7 +39,7 @@ same as using new() constructor. Modulo function-name vs function."
   #                            - annot_gpl = as.logical(NA)
 
   valid_arguments <- list(
-    acc = "GSE123", database = "geo", dl_func_name = "dl_geo_raw",
+    acc = "GSE123", database = "geo", download_method = "dl_geo_raw",
     dest_dir = tempdir(), gpl_acc = "GPL987", annot_gpl = TRUE
   )
   invalid_arguments <- list(
@@ -52,7 +52,7 @@ same as using new() constructor. Modulo function-name vs function."
     # only a single accession is allowed
     list(acc = c("GSE1234", "GSE9876")),
     # not every function is a valid download-function
-    list(dl_func_name = "c"),
+    list(download_method = "c"),
     # for ArrayExpress, the Accession number should be "E-MTAB-..."
     list(database = "aryx", acc = "NOT AN ARRAY EXPRESS ACC")
   )
@@ -79,7 +79,7 @@ test_that("MicroarrayDownloadConfig: validation", {
   # If database is 'geo' then accession-number should be a GSE accession:
   expect_error(
     object = MicroarrayDownloadConfig(
-      acc = "not-a-gse-acc", database = "geo", dl_func_name = "dl_geo_raw",
+      acc = "not-a-gse-acc", database = "geo", download_method = "dl_geo_raw",
       dest_dir = tempdir(), gpl_acc = "GPL987", annot_gpl = TRUE
     ),
     info = "If database is geo, then accession should be GSE*"
@@ -88,7 +88,7 @@ test_that("MicroarrayDownloadConfig: validation", {
   # If gpl_acc is given, it should be a GPL* accession number:
   expect_error(
     object = MicroarrayDownloadConfig(
-      acc = "GSE123", database = "geo", dl_func_name = "dl_geo_raw",
+      acc = "GSE123", database = "geo", download_method = "dl_geo_raw",
       dest_dir = tempdir(), gpl_acc = "not-a-gpl", annot_gpl = TRUE
     ),
     info = "If gpl_acc is given it should be of the form GPL*"
@@ -97,16 +97,16 @@ test_that("MicroarrayDownloadConfig: validation", {
   # If gpl_acc is given, it should be a GPL* accession number:
   expect_error(
     object = MicroarrayDownloadConfig(
-      acc = "GSE123", database = "geo", dl_func_name = "not_a_function",
+      acc = "GSE123", database = "geo", download_method = "not_a_function",
       dest_dir = tempdir(), gpl_acc = "GPL987", annot_gpl = TRUE
     ),
-    info = "dl_func_name should correspond to a defined function"
+    info = "download_method should correspond to a defined function"
   )
 
   # annot_gpl should be a single logical value:
   expect_error(
     object = MicroarrayDownloadConfig(
-      acc = "GSE123", database = "geo", dl_func_name = "dl_geo_raw",
+      acc = "GSE123", database = "geo", download_method = "dl_geo_raw",
       dest_dir = tempdir(), gpl_acc = "GPL987", annot_gpl = "not_logical"
     ),
     info = "annot_gpl should be a logical value"
@@ -114,7 +114,7 @@ test_that("MicroarrayDownloadConfig: validation", {
 
   expect_error(
     object = MicroarrayDownloadConfig(
-      acc = "GSE123", database = "geo", dl_func_name = "dl_geo_raw",
+      acc = "GSE123", database = "geo", download_method = "dl_geo_raw",
       dest_dir = tempdir(), gpl_acc = "GPL987", annot_gpl = c(TRUE, FALSE)
     ),
     info = "annot_gpl should be a single logical value"
@@ -122,10 +122,10 @@ test_that("MicroarrayDownloadConfig: validation", {
 
   expect_error(
     object = MicroarrayDownloadConfig(
-      acc = "GSE123", database = "geo", dl_func_name = "identity",
+      acc = "GSE123", database = "geo", download_method = "identity",
       dest_dir = tempdir(), gpl_acc = "GPL987", annot_gpl = TRUE
     ),
-    info = "args to the function refered by dl_func_name should take 'acc'
+    info = "args to the function refered by download_method should take 'acc'
 and 'dest_dir' as first two args."
   )
 })

--- a/tests/testthat/test-import_classes.R
+++ b/tests/testthat/test-import_classes.R
@@ -44,6 +44,26 @@ test_that("MicroarrayImportConfig: constructor", {
     ),
     info = "MicroarrayImportConfig() must have normalise_method defined"
   )
+
+  expect_equal(
+    object = MicroarrayImportConfig(
+      acc = "GSE1234",
+      import_method = "miiq::import_geo_processed",
+      normalise_method = identity
+    )@import_method,
+    expected = miiq::import_geo_processed,
+    info = "Import method can be specified using pkg::fn syntax"
+  )
+
+  expect_equal(
+    object = MicroarrayImportConfig(
+      acc = "GSE1234",
+      import_method = "miiq::import_geo_processed",
+      normalise_method = "base::identity"
+    )@normalise_method,
+    expected = identity,
+    info = "Normalise method can be specified using pkg::fn syntax"
+  )
 })
 
 ###############################################################################


### PR DESCRIPTION
in `Microarray[Import|Download]Config` functions, the user can now specify `[import|normalise|download]_method` by name or by function. When specified by name, you can use either "some_attached_function" or "pkg::function" syntax