### PR TITLE
add GPL annotations during import workfow

### DIFF
--- a/R/import_classes.R
+++ b/R/import_classes.R
@@ -97,8 +97,7 @@ methods::setMethod(
   signature = methods::signature(
     config = "MicroarrayImportConfig"
   ),
-  definition = function(
-                        config) {
+  definition = function(config) {
     # Import the microarray data & any phenotypic data from the
     # locally-stored files.
     importer <- config@import_method
@@ -107,7 +106,19 @@ methods::setMethod(
     # Background-Correct the microarray data (& create an ExpressionSet) if
     # necessary
     correcter <- config@normalise_method
-    correcter(initial_marray)
+    normalised_marray <- correcter(initial_marray)
+
+    # Append feature annotations from GPL, if a GPL dataset is available
+    final_marray <- if (
+      !is.na(config@gpl_dir) && !is.na(config@gpl_files)
+    ) {
+      gpl <- import_gpl(config@gpl_files, config@gpl_dir)
+      add_gpl_to_eset(normalised_marray, gpl)
+    } else {
+      normalised_marray
+    }
+
+    final_marray
   }
 )
 


### PR DESCRIPTION
When GPL annotation files are available, the annotations should be added during the import workflow steps, rather than the preprocessing (sample filtering etc) workflow