### PR TITLE
Strings as preprocess functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ Suggests:
     testthat (>= 2.1.0),
     covr,
     mockery,
-    withr
+    withr,
+    org.Hs.eg.db
 Imports:
     Biobase,
     limma,

--- a/R/download_classes.R
+++ b/R/download_classes.R
@@ -115,7 +115,6 @@ methods::setClass(
     dest_dir = "character",
     gpl_acc = "character",
     annot_gpl = "logical"
-    # TODO: raw_files, raw_archive, processed_files, samples_file
   )
 )
 

--- a/R/download_classes.R
+++ b/R/download_classes.R
@@ -164,15 +164,11 @@ MicroarrayDownloadConfig <- function(
                                      dest_dir = tempdir(),
                                      gpl_acc = as.character(NA),
                                      annot_gpl) {
-  if (is.character(download_method)) {
-    download_method <- .get_from_env(download_method)
-  }
-
   new(
     "MicroarrayDownloadConfig",
     acc = acc,
     database = database,
-    dl_method = download_method,
+    dl_method = .get_from_env(download_method),
     dest_dir = dest_dir,
     gpl_acc = gpl_acc,
     annot_gpl = annot_gpl

--- a/R/import_classes.R
+++ b/R/import_classes.R
@@ -114,16 +114,11 @@ MicroarrayImportConfig <- function(
   if (missing(import_method)) {
     stop("import_method should be defined")
   }
-  if(is.character(import_method)) {
-    import_method <- .get_from_env(import_method)
-  }
+
   # Ensure that the normalise-method is defined, and, if specified by name
   # convert that function name to the equivalent function.
   if (missing(normalise_method)) {
     stop("normalise_method should be defined")
-  }
-  if (is.character(normalise_method)) {
-    normalise_method <- .get_from_env(normalise_method)
   }
 
   # Tried to do the following with do.call("new",
@@ -131,9 +126,10 @@ MicroarrayImportConfig <- function(
   # problem
   new(
     "MicroarrayImportConfig",
-    acc = acc, import_method = import_method,
-    normalise_method = normalise_method, raw_dir = raw_dir,
-    raw_files = raw_files, raw_archive = raw_archive,
+    acc = acc,
+    import_method = .get_from_env(import_method),
+    normalise_method = .get_from_env(normalise_method),
+    raw_dir = raw_dir, raw_files = raw_files, raw_archive = raw_archive,
     processed_dir = processed_dir, processed_files = processed_files,
     processed_archive = processed_archive,
     sdrf = sdrf, idf = idf, adf = adf, gpl_dir = gpl_dir,

--- a/R/preprocess_classes.R
+++ b/R/preprocess_classes.R
@@ -28,17 +28,20 @@ methods::setMethod(
 )
 
 #' Sets up a class for storing the options for preprocessing ExpressionSets
-#' (that is, filtering the samples and probes; adding entrez and symbol columns)
+#' (that is, filtering the samples and probes; adding entrez and symbol
+#' columns)
 #'
 #' @param        acc           An identifier for the microarray dataset.
 #'   Typically this would be the GEO or ArrayExpress identifier.
-#' @param        entrezgene_db   A string or a OrgDB defining a entrezgene
-#'   database.
+#' @param        entrezgene_db   A string or an \code{OrgDB} defining an
+#'   entrezgene database.
 #' @param        annot_gpl     Logical. Have the features in the dataset been
 #'   annotated with a GPL?
 #' @param        keep_sample_fn,keep_probe_fn   Functions that return a vector
-#'   of integer indices that can be used to subset an ExpressionSet. By default,
-#'   all samples and features will be kept.
+#'   of integer indices that can be used to subset an ExpressionSet. By
+#'   default, all samples and features will be kept. Can be specified as a
+#'   function literal or a "function_name" or a "pkg_name::function_name"
+#'   string.
 #'
 #' @export
 #'
@@ -51,9 +54,9 @@ MicroarrayPreprocessConfig <- function(
   new(
     "MicroarrayPreprocessConfig",
     acc = acc,
-    entrezgene_db = entrezgene_db,
-    keep_sample_fn = keep_sample_fn,
-    keep_probe_fn = keep_probe_fn,
+    entrezgene_db = .get_from_env(entrezgene_db),
+    keep_sample_fn = .get_from_env(keep_sample_fn),
+    keep_probe_fn = .get_from_env(keep_probe_fn),
     annot_gpl = annot_gpl
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,25 +1,28 @@
 #' Obtain an object from a specific package based on a string
 #'
 #' Suppose you provide x = "abc::def", then this will return the `def` function
-#' or variable from the package `abc`. If x = "ghi", then the `ghi` function
-#' or variable from the enclosing environment will be returned
+#' or object from the package `abc`. If x = "ghi", then the `ghi` object from
+#' the enclosing environment will be returned. If the actual variable `ghi`,
+#' rather than it's name, is passed in it will be returned unmodified.
 #'
 #' @param    x        a string in the form "some_object_name" or
-#'   "some_package::some_object_name".
+#'   "some_package::some_object_name". Or, a variable (in which case the
+#'   variable is just returned; this allows the user to not need to know
+#'   whether they are working with a variable or the variable name).
 #'
 
 .get_from_env <- function(x) {
-  stopifnot(is.character(x) && length(x) == 1)
+  if (is.function(x) || is(x, "OrgDb")) {
+    return(x)
+  }
+
+  stopifnot(is.character(x) & length(x) == 1)
 
   env_fn <- strsplit(x, "::")[[1]]
 
   if (length(env_fn) == 1) {
-    env <- -1
-    fn <- env_fn
+    get(env_fn)
   } else {
-    env <- paste0("package:", env_fn[1])
-    fn <- env_fn[2]
+    getExportedValue(env_fn[1], env_fn[2])
   }
-
-  get(fn, pos = env)
 }

--- a/man/MicroarrayPreprocessConfig.Rd
+++ b/man/MicroarrayPreprocessConfig.Rd
@@ -3,7 +3,8 @@
 \name{MicroarrayPreprocessConfig}
 \alias{MicroarrayPreprocessConfig}
 \title{Sets up a class for storing the options for preprocessing ExpressionSets
-(that is, filtering the samples and probes; adding entrez and symbol columns)}
+(that is, filtering the samples and probes; adding entrez and symbol
+columns)}
 \usage{
 MicroarrayPreprocessConfig(acc, entrezgene_db,
   keep_sample_fn = gld_fnDefault_keepSample,
@@ -13,17 +14,20 @@ MicroarrayPreprocessConfig(acc, entrezgene_db,
 \item{acc}{An identifier for the microarray dataset.
 Typically this would be the GEO or ArrayExpress identifier.}
 
-\item{entrezgene_db}{A string or a OrgDB defining a entrezgene
-database.}
+\item{entrezgene_db}{A string or an \code{OrgDB} defining an
+entrezgene database.}
 
 \item{keep_sample_fn, keep_probe_fn}{Functions that return a vector
-of integer indices that can be used to subset an ExpressionSet. By default,
-all samples and features will be kept.}
+of integer indices that can be used to subset an ExpressionSet. By
+default, all samples and features will be kept. Can be specified as a
+function literal or a "function_name" or a "pkg_name::function_name"
+string.}
 
 \item{annot_gpl}{Logical. Have the features in the dataset been
 annotated with a GPL?}
 }
 \description{
 Sets up a class for storing the options for preprocessing ExpressionSets
-(that is, filtering the samples and probes; adding entrez and symbol columns)
+(that is, filtering the samples and probes; adding entrez and symbol
+columns)
 }

--- a/man/dot-get_from_env.Rd
+++ b/man/dot-get_from_env.Rd
@@ -8,10 +8,13 @@
 }
 \arguments{
 \item{x}{a string in the form "some_object_name" or
-"some_package::some_object_name".}
+"some_package::some_object_name". Or, a variable (in which case the
+variable is just returned; this allows the user to not need to know
+whether they are working with a variable or the variable name).}
 }
 \description{
 Suppose you provide x = "abc::def", then this will return the `def` function
-or variable from the package `abc`. If x = "ghi", then the `ghi` function
-or variable from the enclosing environment will be returned
+or object from the package `abc`. If x = "ghi", then the `ghi` object from
+the enclosing environment will be returned. If the actual variable `ghi`,
+rather than it's name, is passed in it will be returned unmodified.
 }

--- a/tests/testthat/test-preprocess_classes.R
+++ b/tests/testthat/test-preprocess_classes.R
@@ -16,7 +16,33 @@ test_that("MicroarrayPreprocessConfig", {
     info = "MicroarrayPreprocessConfig() constructor returns the correct class"
   )
 
-  # TODO:
-  # user can pass the name of an OrgDb instead of an actual OrgDb, and the
-  # constructor will get pass the correct database to MicroarrayPreprocessConfig
+  expect_equal(
+    MicroarrayPreprocessConfig(
+      "GSE12345", mock_db, keep_sample_fn = "identity"
+    )@keep_sample_fn,
+    expected = identity,
+    info = paste(
+      "`MicroarrayPreprocessConfig()` can take a `keep_sample_fn` as a string"
+    )
+  )
+
+  expect_equal(
+    MicroarrayPreprocessConfig(
+      "GSE12345", mock_db, keep_probe_fn = "identity"
+    )@keep_probe_fn,
+    expected = identity,
+    info = paste(
+      "`MicroarrayPreprocessConfig()` can take a `keep_probe_fn` as a string"
+    )
+  )
+
+  expect_equal(
+    MicroarrayPreprocessConfig(
+      "GSE12345", "org.Hs.eg.db::org.Hs.eg.db"
+    )@entrezgene_db,
+    expected = org.Hs.eg.db::org.Hs.eg.db,
+    info = paste(
+      "`MicroarrayPreprocessConfig()` can take an `entrezgene_db` as a string"
+    )
+  )
 })


### PR DESCRIPTION
get objects from string in MicroarrayPreprocessConfig()
    
    In a MicroarrayPreprocessConfig object, the keep_sample_fn,
    keep_probe_fn and entrezgene_db objects should be functions (in the
    first two cases) or OrgDb objects (in the latter).
    
    Here we allow the user to specify these objects by their name in the
    form `some_pkg::some_object` or `some_object` (when the objects are
    in the calling env).

To achieve this, we generalised `.get_from_env` to pass back function-literals (closures) or database objects, when the actual object is passed in, or to get the appropriate object when the name of that object is passed in.